### PR TITLE
feat: basic in-memory adapter

### DIFF
--- a/adapter/inmemory.go
+++ b/adapter/inmemory.go
@@ -1,0 +1,63 @@
+// Package adapter provides a way to work with flags and metrics
+package adapter
+
+import (
+	"context"
+	"fmt"
+)
+
+// InMemoryFlag structure represents a flag that is stored in memory
+type InMemoryFlag struct {
+	Value interface{}
+}
+
+// InMemory is an adapter that stores flags in memory
+type InMemory struct {
+	Flags map[string]InMemoryFlag
+}
+
+// NewInMemory returns a new InMemory adapter
+func NewInMemory() *InMemory {
+	return &InMemory{
+		Flags: make(map[string]InMemoryFlag),
+	}
+}
+
+// BooleanEvaluation returns the value of a boolean flag
+func (i *InMemory) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool) (bool, error) {
+	memoryFlag, ok := i.find(flag)
+	if !ok {
+		return defaultValue, nil
+	}
+
+	return genericResolve[bool](memoryFlag.Value, defaultValue)
+}
+
+// SetBoolean sets the value of a boolean flag
+func (i *InMemory) SetBoolean(ctx context.Context, flag string, value bool) error {
+	i.Flags[flag] = InMemoryFlag{
+		Value: value,
+	}
+	return nil
+}
+
+func (i *InMemory) find(flag string) (InMemoryFlag, bool) {
+	memoryFlag, ok := i.Flags[flag]
+	if !ok {
+		return InMemoryFlag{}, false
+	}
+
+	return memoryFlag, true
+}
+
+func genericResolve[T any](flag interface{}, defaultValue T) (T, error) {
+	if flag == nil {
+		return defaultValue, nil
+	}
+
+	if v, ok := flag.(T); ok {
+		return v, nil
+	}
+
+	return defaultValue, fmt.Errorf("type assertion failed")
+}

--- a/client.go
+++ b/client.go
@@ -1,0 +1,57 @@
+// Package kickplan provides a client to evaluate feature flags and work with metrics
+package kickplan
+
+import (
+	"context"
+
+	"github.com/kickplan/sdk-go/adapter"
+)
+
+// EvalContext is a map that represents the context of an evaluation
+type EvalContext map[string]interface{}
+
+// Adapter is an interface that defines the methods that a client adapter must implement
+type Adapter interface {
+	BooleanEvaluation(ctx context.Context, flag string, defaultValue bool) (bool, error)
+	SetBoolean(ctx context.Context, flag string, value bool) error
+}
+
+// Client is a Kickplan client
+type Client struct {
+	adapter Adapter
+}
+
+// Option is a function that configures a Client
+type Option func(*Client) error
+
+// NewClient returns a new Kickplan client
+func NewClient(opt ...Option) *Client {
+	c := new(Client)
+	for _, o := range opt {
+		o(c)
+	}
+
+	if c.adapter == nil {
+		c.adapter = adapter.NewInMemory()
+	}
+
+	return c
+}
+
+// WithAdapter sets the provider for the client
+func WithAdapter(adapter Adapter) Option {
+	return func(c *Client) error {
+		c.adapter = adapter
+		return nil
+	}
+}
+
+// GetBool returns a boolean flag
+func (c *Client) GetBool(ctx context.Context, flag string, defaultValue bool) (bool, error) {
+	return c.adapter.BooleanEvaluation(ctx, flag, defaultValue)
+}
+
+// SetBool sets a boolean flag
+func (c *Client) SetBool(ctx context.Context, flag string, value bool) error {
+	return c.adapter.SetBoolean(ctx, flag, value)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,42 @@
+package kickplan
+
+import (
+	"testing"
+
+	"github.com/kickplan/sdk-go/adapter"
+)
+
+func TestDefaultAdapter(t *testing.T) {
+	client := NewClient()
+	if client.adapter == nil {
+		t.Fatalf("expected adapter to be set")
+	}
+
+	_, ok := client.adapter.(*adapter.InMemory)
+	if !ok {
+		t.Fatalf("expected adapter to be of type InMemory")
+	}
+
+	b, err := client.GetBool(nil, "my-flag", false)
+	if err != nil {
+		t.Fatalf("failed to get flag: %v", err)
+	}
+
+	if b != false {
+		t.Fatalf("expected flag to be false")
+	}
+
+	err = client.SetBool(nil, "my-flag", true)
+	if err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	b, err = client.GetBool(nil, "my-flag", false)
+	if err != nil {
+		t.Fatalf("failed to get flag: %v", err)
+	}
+
+	if b != true {
+		t.Fatalf("expected flag to be true")
+	}
+}

--- a/examples/inmemory/main.go
+++ b/examples/inmemory/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	kickplan "github.com/kickplan/sdk-go"
+)
+
+func main() {
+	ctx := context.Background()
+	client := kickplan.NewClient()
+
+	const flag = "my-flag"
+
+	b, err := client.GetBool(ctx, flag, false)
+	if err != nil {
+		log.Fatalf("failed to get flag: %v", err)
+		return
+	}
+
+	log.Printf("my-flag: %v", b)
+
+	err = client.SetBool(ctx, flag, true)
+	if err != nil {
+		log.Fatalf("failed to set flag: %v", err)
+		return
+	}
+
+	log.Printf("updated my-flag")
+
+	b, err = client.GetBool(ctx, flag, false)
+	if err != nil {
+		log.Fatalf("failed to get flag: %v", err)
+		return
+	}
+
+	log.Printf("my-flag: %v", b)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kickplan/sdk-go
+
+go 1.21.3


### PR DESCRIPTION
Here is some basic implementation of a client with an "InMemory" adapter that can only read or write bool values.

Apparently, [open-feature/go-sdk](https://github.com/open-feature/go-sdk) doesn't provide a way to update flag values on the fly. Still, there are many good ideas for organizing code with context evaluation and generic resolvers.

This PR demonstrates the potential approach before getting too deep into context evaluation, variants, and another adapter.