### PR TITLE
feat: add CreateAccount call

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -20,6 +20,8 @@ type Adapter interface {
 	SetMetric(ctx context.Context, metric string, value int64, evalCtx eval.Context) error
 	IncMetric(ctx context.Context, metric string, value int64, evalCtx eval.Context) error
 	DecMetric(ctx context.Context, metric string, value int64, evalCtx eval.Context) error
+
+	CreateAccount(ctx context.Context, key, name string, planKeys ...string) error
 }
 
 func genericResolve[T any](flag interface{}, defaultValue T) (T, error) {

--- a/adapter/inmemory.go
+++ b/adapter/inmemory.go
@@ -114,6 +114,11 @@ func (i *InMemory) DecMetric(_ context.Context, metric string, value int64, _ ev
 	return nil
 }
 
+// CreateAccount stub.
+func (i *InMemory) CreateAccount(_ context.Context, _, _ string, _ ...string) error {
+	return nil
+}
+
 func (i *InMemory) find(flag string) (InMemoryFlag, bool) {
 	memoryFlag, ok := i.Flags[flag]
 	if !ok {

--- a/adapter/kickplan_test.go
+++ b/adapter/kickplan_test.go
@@ -286,3 +286,53 @@ func TestMetricDecrement(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCreateAccount(t *testing.T) {
+	DoFunc = func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://api.domain.com/accounts" {
+			t.Fatalf("expected request endpoint to be https://api.domain.com/accounts, got %s", req.URL.String())
+		}
+
+		if req.Method != http.MethodPost {
+			t.Fatalf("expected request method to be POST, got %s", req.Method)
+		}
+
+		var body CreateAccountRequest
+		err := json.NewDecoder(req.Body).Decode(&body)
+		if err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		if body.Key != "key" {
+			t.Fatalf("expected request key to be \"key\", got %q", body.Key)
+		}
+
+		if body.Name != "Name" {
+			t.Fatalf("expected request name to be \"Name\", got %q", body.Name)
+		}
+
+		if len(body.Plans) != 2 {
+			t.Fatalf("expected request plans to be have 2 items, got %d", len(body.Plans))
+		}
+
+		if body.Plans[0].PlanKey != "free" {
+			t.Fatalf("expected request plans to be [\"free\"], got %q", body.Plans)
+		}
+
+		if body.Plans[1].PlanKey != "pro" {
+			t.Fatalf("expected request plans to be [\"pro\"], got %q", body.Plans)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(bytes.NewReader([]byte(``))),
+		}, nil
+	}
+
+	adapter := Kickplan{client: &mockClient{}, endpoint: "https://api.domain.com"}
+
+	err := adapter.CreateAccount(context.Background(), "key", "Name", "free", "pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -126,3 +126,12 @@ func (c *Client) DecMetric(
 ) error {
 	return c.adapter.DecMetric(ctx, metric, value, evalCtx)
 }
+
+// CreateAccount creates account and assigns plan keys to it.
+func (c *Client) CreateAccount(
+	ctx context.Context,
+	key, name string,
+	planKeys ...string,
+) error {
+	return c.adapter.CreateAccount(ctx, key, name, planKeys...)
+}


### PR DESCRIPTION
This PR adds implementation for `POST /accounts` request that creates new account and assigns plan keys to it.

Example usage:

```go
ctx := context.Background()
client := kickplan.NewClient()

// Create new account with "free" and "pro" plans
err := client.CreateAccount(ctx, "key", "Name", "free", "pro")
if err != nil {
	log.Fatalf("failed to create account: %v", err)
}
```